### PR TITLE
Add container based on RHEL 6.7

### DIFF
--- a/rhel-6.7/Dockerfile
+++ b/rhel-6.7/Dockerfile
@@ -1,0 +1,20 @@
+FROM rhel6.7
+MAINTAINER "Pavel Studenik" <pstudeni@redhat.com>
+
+RUN yum -y remove subscription-manager python-rhsm
+RUN rpm -Uvh http://yum.spacewalkproject.org/nightly-client/RHEL/6/x86_64/spacewalk-client-repo-2.4-3.el6.noarch.rpm
+RUN sed s/enabled=0/enabled=1/g /etc/yum.repos.d/spacewalk-client-nightly.repo -i
+RUN sed s/enabled=1/enabled=0/g /etc/yum.repos.d/spacewalk-client.repo -i
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+RUN echo -e "[rhel67]\nname=RHEL67\nbaseurl=http://download.devel.redhat.com/rel-eng/RHEL-6.7-20150702.0/6/Server/x86_64/os/\nenabled=1\ngpgcheck=0" >/etc/yum.repos.d/rhel67.repo
+RUN yum install rhn-client-tools rhn-check rhn-setup rhnsd m2crypto wget osad yum-rhn-plugin rhnlib -y
+RUN yum upgrade rhn-client-tools rhn-check rhn-setup rhnsd m2crypto wget osad yum-rhn-plugin rhnlib -y
+RUN rm -f /etc/yum.repos.d/rhel67.repo
+
+ADD register.sh /root/register.sh
+ADD osad.sh /root/osad.sh
+
+RUN chmod a+x /root/{register.sh,osad.sh}
+
+CMD /root/osad.sh
+

--- a/rhel-6.7/osad.sh
+++ b/rhel-6.7/osad.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/root/register.sh $1 $2 $3 && \
+
+rhn_check -vv && \
+/usr/bin/python -s /usr/sbin/osad --pid-file /var/run/osad.pid -N

--- a/rhel-6.7/register.sh
+++ b/rhel-6.7/register.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# author: Pavel Studenik <pstudeni@redhat.com>
+
+# register.sh <username> <password> <server>
+
+function show_log {
+   count_log_2=$( cat /var/log/up2date | wc -l )
+   num=$(( count_log_2 - $1 ))
+   tail -n $num /var/log/up2date
+}
+
+RHN_USER=${1:-$RHN_USER}
+RHN_PASS=${2:-$RHN_PASS}
+RHN_SERVER=${3:-$RHN_SERVER}
+
+curl -o /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT http://$RHN_SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT
+
+touch /var/log/up2date
+count_log=$( cat /var/log/up2date | wc -l  )
+
+rhnreg_ks --username=$RHN_USER --password=$RHN_PASS --force \
+ --serverUrl=https://$RHN_SERVER/XMLRPC \
+ --sslCACert=/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT || show_log count_log
+
+rhn_check -vv || echo "ERROR: system is not registered"
+


### PR DESCRIPTION
Biggest change is I have remove installing rhncfg from register.sh as I would expect the script just to register and not to install additional packages. Some additional repos and other small changes were required as well.

I do not know how to work with Docker, so I have just tried to build it according to your README.md and run it. For some reason it hangs when you run it, although registration seems to pass. If you attempt to build it, you have to edit Dockerfile and change row with "example.com" to point to your RHEL 6.7 yum repo (SW client tools and their dependencies will pull additional dependencies from there).
